### PR TITLE
feat: tablet view changes for languages

### DIFF
--- a/packages/account/src/Sections/Profile/LanguageSettings/language-settings.tsx
+++ b/packages/account/src/Sections/Profile/LanguageSettings/language-settings.tsx
@@ -6,21 +6,22 @@ import { routes } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import FormSubHeader from 'Components/form-sub-header';
 import LanguageRadioButton from 'Components/language-settings';
+import { useDevice } from '@deriv-com/ui';
 
 const LanguageSettings = observer(() => {
-    const { common, ui } = useStore();
-    const { is_mobile } = ui;
+    const { common } = useStore();
     const { changeSelectedLanguage, current_language } = common;
     const { has_wallet } = useStoreWalletAccountsList();
+    const { isDesktop } = useDevice();
 
-    if (is_mobile || has_wallet) {
+    if (!isDesktop || has_wallet) {
         return <Redirect to={routes.traders_hub} />;
     }
 
     const allowed_language_keys: string[] = Object.keys(getAllowedLanguages());
     return (
         <div className='settings-language'>
-            <FormSubHeader title={localize('Select Language')} />
+            <FormSubHeader title={localize('Select language')} />
             <div className='settings-language__language-container'>
                 {allowed_language_keys.map(language_key => {
                     return (

--- a/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/mobile-language-menu.tsx
+++ b/packages/core/src/App/Components/Layout/Header/Components/ToggleMenu/mobile-language-menu.tsx
@@ -18,7 +18,7 @@ const MobileLanguageMenu = observer(({ expandSubMenu, toggleDrawer }: TMobileLan
         <MobileDrawer.SubMenu
             is_expanded={is_mobile_language_menu_open}
             has_subheader
-            submenu_title={localize('Language')}
+            submenu_title={localize('Select language')}
             onToggle={is_expanded => {
                 expandSubMenu(is_expanded);
                 setMobileLanguageMenuOpen(false);

--- a/packages/core/src/App/Components/Layout/Header/menu-link.tsx
+++ b/packages/core/src/App/Components/Layout/Header/menu-link.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import classNames from 'classnames';
 import { Icon, Text } from '@deriv/components';
 import { useIsRealAccountNeededForCashier } from '@deriv/hooks';
-import { isMobile, routes, getStaticUrl } from '@deriv/shared';
+import { routes, getStaticUrl } from '@deriv/shared';
 import { isExternalLink } from '@deriv/utils';
 import { observer, useStore } from '@deriv/stores';
 import { localize } from '@deriv/translations';
 import { BinaryLink } from 'App/Components/Routes';
+import { useDevice } from '@deriv-com/ui';
 
 type TMenuLink = {
     data_testid: string;
@@ -33,13 +34,14 @@ const MenuLink = observer(
         text,
     }: Partial<TMenuLink>) => {
         const { ui, client } = useStore();
+        const { isDesktop } = useDevice();
         const { has_any_real_account, is_virtual } = client;
         const { setMobileLanguageMenuOpen, toggleReadyToDepositModal, toggleNeedRealAccountForCashierModal } = ui;
         const real_account_needed_for_cashier = useIsRealAccountNeededForCashier();
         const is_trade_text = text === localize('Trade');
         const deriv_static_url = getStaticUrl(link_to);
         const traders_hub_path = window.location.pathname === routes.traders_hub;
-        const is_languages_link_on_mobile = isMobile() && link_to === routes.languages;
+        const is_languages_link_on_responsive = !isDesktop && link_to === routes.languages;
         const is_external_link = deriv_static_url && isExternalLink(link_to);
         const is_cashier_link = [
             routes.cashier_deposit,
@@ -49,7 +51,7 @@ const MenuLink = observer(
 
         if (is_hidden) return null;
 
-        if (is_languages_link_on_mobile) {
+        if (is_languages_link_on_responsive) {
             return (
                 <div
                     className={classNames('header__menu-mobile-link', {

--- a/packages/core/src/sass/app/_common/components/settings-language.scss
+++ b/packages/core/src/sass/app/_common/components/settings-language.scss
@@ -3,7 +3,7 @@
     margin-left: 1.6rem;
     width: fit-content;
 
-    @include mobile {
+    @include mobile-or-tablet-screen {
         display: flex;
         flex-direction: column;
         padding: 1.6rem 2.2rem 8rem;
@@ -17,14 +17,14 @@
         grid-gap: 0.8rem;
         margin: 1.6rem 0;
 
-        @include mobile {
+        @include mobile-or-tablet-screen {
             grid-template-columns: repeat(2, minmax(40%, 1fr));
             grid-template-rows: auto;
             grid-gap: initial;
             margin: 0 auto;
             padding: 0 0.8rem;
 
-            @include mobile {
+            @include mobile-or-tablet-screen {
                 &--disabled {
                     opacity: 0.5;
                     pointer-events: none;
@@ -49,7 +49,7 @@
             width: 13.6rem;
             height: 8.8rem;
 
-            @include mobile {
+            @include mobile-or-tablet-screen {
                 padding: 8px;
 
                 &--pre-appstore {
@@ -76,7 +76,7 @@
             width: 3.6rem;
             height: 2.8rem;
 
-            @include mobile {
+            @include mobile-or-tablet-screen {
                 margin-top: 1rem;
             }
         }
@@ -90,7 +90,7 @@
                 color: var(--text-prominent);
             }
 
-            @include mobile {
+            @include mobile-or-tablet-screen {
                 font-size: 1.4rem;
             }
         }


### PR DESCRIPTION
## Changes:

- Add tablet view for language in side menu
- Change name of language header in mobile/tablet to `Select language` from `language`
- Change name of language header in mobile/tablet to `Select language` from `Select Language`
- Fix redirection to `MobileLangMenu` upon clicking the languages inside mobile-menu

### Screenshots:
<img width="1271" alt="Screenshot 2024-05-17 at 12 34 16 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/125863995/585f08cb-10f0-4310-b864-663909e6251a">
