### PR TITLE
Tablet view for login history section

### DIFF
--- a/packages/account/src/Sections/Security/LoginHistory/__test__/login-history-list-row.spec.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/__test__/login-history-list-row.spec.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
-import { StoreProvider, mockStore } from '@deriv/stores';
 import { APIProvider } from '@deriv/api';
+import { useDevice } from '@deriv-com/ui';
 import LoginHistoryListRow from '../login-history-list-row';
 
-describe('LoginHistoryListRow', () => {
-    let mock_store: ReturnType<typeof mockStore>;
+jest.mock('@deriv-com/ui', () => ({
+    ...jest.requireActual('@deriv-com/ui'),
+    useDevice: jest.fn(() => ({ isDesktop: true })),
+}));
 
+describe('LoginHistoryListRow', () => {
     const mock_props: React.ComponentProps<typeof LoginHistoryListRow> = {
         id: 0,
         date: '2023-08-29 07:05:35 GMT',
@@ -17,21 +20,10 @@ describe('LoginHistoryListRow', () => {
     };
 
     const renderComponent = () => {
-        const wrapper = ({ children }: { children: JSX.Element }) => (
-            <APIProvider>
-                <StoreProvider store={mock_store}>{children}</StoreProvider>
-            </APIProvider>
-        );
+        const wrapper = ({ children }: { children: JSX.Element }) => <APIProvider>{children}</APIProvider>;
         render(<LoginHistoryListRow {...mock_props} />, { wrapper });
     };
 
-    beforeEach(() => {
-        mock_store = mockStore({
-            ui: {
-                is_desktop: true,
-            },
-        });
-    });
     it('should render LoginHistoryListRow Table Title', () => {
         const titles = [/date and time/i, /browser/i, /ip address/i, /action/i, /status/i];
         renderComponent();
@@ -55,7 +47,7 @@ describe('LoginHistoryListRow', () => {
     });
 
     it('should not render Status if is not desktop', () => {
-        mock_store.ui.is_desktop = false;
+        (useDevice as jest.Mock).mockReturnValue({ isDesktop: false });
         renderComponent();
         expect(screen.queryByText('status')).not.toBeInTheDocument();
         expect(screen.queryByText('successful')).not.toBeInTheDocument();

--- a/packages/account/src/Sections/Security/LoginHistory/__test__/login-history.spec.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/__test__/login-history.spec.tsx
@@ -2,8 +2,14 @@ import React from 'react';
 import { screen, render, waitFor } from '@testing-library/react';
 import { WS } from '@deriv/shared';
 import { StoreProvider, mockStore } from '@deriv/stores';
+import { useDevice } from '@deriv-com/ui';
 import LoginHistory from '../login-history';
 import { getLoginHistoryFormattedData } from '../../../../../../utils/src/getLoginHistoryFormattedData';
+
+jest.mock('@deriv-com/ui', () => ({
+    ...jest.requireActual('@deriv-com/ui'),
+    useDevice: jest.fn(() => ({ isDesktop: true })),
+}));
 
 jest.mock('@deriv/components', () => ({
     ...jest.requireActual('@deriv/components'),
@@ -63,18 +69,11 @@ describe('<LoginHistory />', () => {
                 is_switching: false,
                 is_authorize: true,
             },
-            ui: {
-                is_mobile: false,
-            },
         });
     });
 
-    it('should render Login History List when is_mobile is true', async () => {
-        mock_store.ui.is_mobile = true;
-        renderComponent();
-        await waitFor(() => {
-            expect(screen.getByText(/date and time/i)).toHaveClass('dc-text login-history__list__row__cell--title');
-        });
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
     it('should render Login History Table', async () => {
@@ -151,6 +150,14 @@ describe('<LoginHistory />', () => {
         renderComponent();
         await waitFor(() => {
             expect(screen.getByText(/failed/i)).toBeInTheDocument();
+        });
+    });
+
+    it('should render Login History List when is_mobile is true', async () => {
+        (useDevice as jest.Mock).mockReturnValue({ isDesktop: false });
+        renderComponent();
+        await waitFor(() => {
+            expect(screen.getByText(/date and time/i)).toHaveClass('dc-text login-history__list__row__cell--title');
         });
     });
 

--- a/packages/account/src/Sections/Security/LoginHistory/login-history-content.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/login-history-content.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Table } from '@deriv/components';
-import { observer } from '@deriv/stores';
 import { useDevice } from '@deriv-com/ui';
 import getLoginHistoryTableHeaders from 'Constants/get-login-history-table-headers';
 import LoginHistoryTableRow from './login-history-table-row';
@@ -23,11 +22,11 @@ type TLoginHistoryContent = {
     data: TLoginHistoryData;
 };
 
-const LoginHistoryContent = observer(({ data }: TLoginHistoryContent) => {
+const LoginHistoryContent = ({ data }: TLoginHistoryContent) => {
     const { isDesktop } = useDevice();
 
     return isDesktop ? renderTable(getLoginHistoryTableHeaders(), data) : renderList(data);
-});
+};
 
 const renderTable = (fields: TGetFields, login_history: TLoginHistoryData) => (
     <Table fixed className='login-history__table'>

--- a/packages/account/src/Sections/Security/LoginHistory/login-history-content.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/login-history-content.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Table } from '@deriv/components';
-import { observer, useStore } from '@deriv/stores';
+import { observer } from '@deriv/stores';
+import { useDevice } from '@deriv-com/ui';
 import getLoginHistoryTableHeaders from 'Constants/get-login-history-table-headers';
 import LoginHistoryTableRow from './login-history-table-row';
 import LoginHistoryListRow from './login-history-list-row';
@@ -23,10 +24,9 @@ type TLoginHistoryContent = {
 };
 
 const LoginHistoryContent = observer(({ data }: TLoginHistoryContent) => {
-    const { ui } = useStore();
-    const { is_mobile } = ui;
+    const { isDesktop } = useDevice();
 
-    return is_mobile ? renderList(data) : renderTable(getLoginHistoryTableHeaders(), data);
+    return isDesktop ? renderTable(getLoginHistoryTableHeaders(), data) : renderList(data);
 });
 
 const renderTable = (fields: TGetFields, login_history: TLoginHistoryData) => (

--- a/packages/account/src/Sections/Security/LoginHistory/login-history-list-row.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/login-history-list-row.tsx
@@ -6,9 +6,8 @@ import { Localize } from '@deriv/translations';
 import { useDevice } from '@deriv-com/ui';
 import getLoginHistoryTableHeaders from 'Constants/get-login-history-table-headers';
 import ListCell from './list-cell';
-import { observer } from '@deriv/stores';
 
-const LoginHistoryListRow = observer(({ id, date, action, browser, ip, status }: TLoginHistoryItems) => {
+const LoginHistoryListRow = ({ id, date, action, browser, ip, status }: TLoginHistoryItems) => {
     const { date_title, browser_title, action_title, ip_title, status_title } = getLoginHistoryTableHeaders();
     const { isDesktop } = useDevice();
 
@@ -50,6 +49,6 @@ const LoginHistoryListRow = observer(({ id, date, action, browser, ip, status }:
             </Table.Row>
         </div>
     );
-});
+};
 
 export default LoginHistoryListRow;

--- a/packages/account/src/Sections/Security/LoginHistory/login-history-list-row.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/login-history-list-row.tsx
@@ -3,14 +3,15 @@ import classNames from 'classnames';
 import { TLoginHistoryItems } from 'Types';
 import { Table } from '@deriv/components';
 import { Localize } from '@deriv/translations';
+import { useDevice } from '@deriv-com/ui';
 import getLoginHistoryTableHeaders from 'Constants/get-login-history-table-headers';
 import ListCell from './list-cell';
-import { observer, useStore } from '@deriv/stores';
+import { observer } from '@deriv/stores';
 
 const LoginHistoryListRow = observer(({ id, date, action, browser, ip, status }: TLoginHistoryItems) => {
     const { date_title, browser_title, action_title, ip_title, status_title } = getLoginHistoryTableHeaders();
-    const { ui } = useStore();
-    const { is_desktop } = ui;
+    const { isDesktop } = useDevice();
+
     return (
         <div className={classNames('login-history__list__wrapper')} key={id}>
             <Table.Row className='login-history__list__row login-history__list__row--with-margin'>
@@ -38,7 +39,7 @@ const LoginHistoryListRow = observer(({ id, date, action, browser, ip, status }:
                 <Table.Cell className='login-history__list__row__cell'>
                     <ListCell className='login-history__list__row__cell--ip-value' title={ip_title} text={ip} />
                 </Table.Cell>
-                {is_desktop && (
+                {isDesktop && (
                     <Table.Cell className='login-history__list__row__cell'>
                         <ListCell
                             title={status_title}

--- a/packages/account/src/Sections/Security/LoginHistory/login-history.tsx
+++ b/packages/account/src/Sections/Security/LoginHistory/login-history.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Loading, ThemedScrollbars } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import { WS, useIsMounted } from '@deriv/shared';
+import { useDevice } from '@deriv-com/ui';
 import LoadErrorMessage from 'Components/load-error-message';
 import LoginHistoryContent from './login-history-content';
 import { getLoginHistoryFormattedData } from '../../../../../utils/src/getLoginHistoryFormattedData';
@@ -9,9 +10,9 @@ import { getLoginHistoryFormattedData } from '../../../../../utils/src/getLoginH
 type TLoginData = { id: number; date: string; action: string; browser: string; ip: string; status: string }[];
 
 const LoginHistory = observer(() => {
-    const { client, ui } = useStore();
+    const { client } = useStore();
+    const { isDesktop } = useDevice();
     const { is_switching } = client;
-    const { is_mobile } = ui;
     const [is_loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState('');
     const [data, setData] = React.useState<TLoginData>([]);
@@ -39,7 +40,7 @@ const LoginHistory = observer(() => {
     if (error) return <LoadErrorMessage error_message={error} />;
 
     return (
-        <ThemedScrollbars is_bypassed={is_mobile} className='login-history'>
+        <ThemedScrollbars is_bypassed={!isDesktop} className='login-history'>
             {data.length > 0 ? <LoginHistoryContent data={data} /> : null}
         </ThemedScrollbars>
     );

--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -1009,7 +1009,7 @@ $MIN_HEIGHT_FLOATING: calc(
             }
         }
 
-        @include mobile {
+        @include mobile-or-tablet-screen {
             &__list {
                 width: 90%;
                 margin: 1rem auto;


### PR DESCRIPTION
## Changes:

- tablet view changes
- replace store with `useDevice`
- replace old mixins with new
- add logical css
- edit testcases bcz of the usage of new hook

### Screenshots:
<img width="983" alt="Screenshot 2024-05-23 at 5 05 37 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/125863995/eea093d7-7863-4590-9c58-4e88a976dd9c">

