### PR TITLE
fix: fieldset max width

### DIFF
--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -1751,7 +1751,6 @@ $MIN_HEIGHT_FLOATING: calc(
                     @include mobile-or-tablet-screen {
                         position: fixed;
                         bottom: 0;
-                        left: 0;
                         background: var(--general-main-1);
                         width: 100vw;
                         margin: unset;

--- a/packages/components/src/components/select-native/select-native.scss
+++ b/packages/components/src/components/select-native/select-native.scss
@@ -56,7 +56,7 @@
         padding-left: 1.2rem;
 
         @include tablet-screen {
-            max-width: 568rem;
+            max-width: 56.8rem;
         }
 
         &-text {

--- a/packages/components/src/components/select-native/select-native.scss
+++ b/packages/components/src/components/select-native/select-native.scss
@@ -55,6 +55,10 @@
         justify-content: flex-start;
         padding-left: 1.2rem;
 
+        @include tablet-screen {
+            max-width: 568px;
+        }
+
         &-text {
             color: var(--text-prominent);
             font-size: 1.4rem;

--- a/packages/components/src/components/select-native/select-native.scss
+++ b/packages/components/src/components/select-native/select-native.scss
@@ -56,7 +56,7 @@
         padding-left: 1.2rem;
 
         @include tablet-screen {
-            max-width: 568px;
+            max-width: 568rem;
         }
 
         &-text {


### PR DESCRIPTION
## Changes:

- fix overflow issue for fields by fixing the max-width to 568px.
- close account section btn alignment -> moved from sticking with screen to sticking with container

### Screenshots:

<img width="794" alt="Screenshot 2024-06-05 at 3 37 15 PM" src="https://github.com/binary-com/deriv-app/assets/125863995/74268c38-cd2d-4955-bf1a-238417056122">
<img width="972" alt="Screenshot 2024-06-05 at 3 42 03 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/125863995/cae04f05-fff1-4a85-b2ed-c1ded9c14dd7">
