### PR TITLE
Fixed scroll and padding in Proof of Identity- Tablet View/dhruv 

### DIFF
--- a/packages/core/src/sass/app/_common/components/account-common.scss
+++ b/packages/core/src/sass/app/_common/components/account-common.scss
@@ -728,6 +728,7 @@
     &__main-container {
         @include mobile-or-tablet-screen {
             max-width: 100%;
+            overflow: hidden;
         }
         max-width: 68.2rem;
         height: 100%;
@@ -753,7 +754,7 @@
 
         @include mobile-or-tablet-screen {
             overflow-y: scroll;
-            padding: 0 1.6rem;
+            padding: 2.4rem 0 1.6rem;
 
             &--status {
                 height: 100%;


### PR DESCRIPTION
### **Changes:**

In the 'Proof of Identity' section for tablet view fixed :-
1. Adjust and refine the scroll behavior  
2. Padding of the Failed Status message 

### **Screenshots:**

### _Issue:_

![Screenshot 2024-06-05 at 4 52 07 PM](https://github.com/fasihali-deriv/deriv-app/assets/158162395/6c4bd930-153a-4219-8f02-ad3f5af0dc15)

<img width="859" alt="Screenshot 2024-06-05 at 4 52 38 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/158162395/a2cc0584-074d-4088-91c6-3db1e01b0139">

### _Resolved:_

![Screenshot 2024-06-05 at 4 53 23 PM](https://github.com/fasihali-deriv/deriv-app/assets/158162395/9358e143-c043-4c12-b53e-700d99b5acf2)

<img width="865" alt="Screenshot 2024-06-05 at 4 56 25 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/158162395/1c737473-27c5-4d7b-b47b-caa66f7ec01a">




