### PR TITLE
Dhruv/White Space and Scroll issue in Mobile and Tablet View

### DIFF
--- a/packages/account/src/Components/form-body/form-body.tsx
+++ b/packages/account/src/Components/form-body/form-body.tsx
@@ -26,7 +26,7 @@ export const FormBody = ({ children, scroll_offset, className, isFullHeight }: P
             ) : (
                 <Div100vhContainer
                     className={clsx('account__scrollbars_container--grid-layout', className)}
-                    height_offset={scroll_offset || '200px'}
+                    height_offset={scroll_offset || '100%'}
                 >
                     {children}
                 </Div100vhContainer>

--- a/packages/core/src/sass/app/_common/components/account-common.scss
+++ b/packages/core/src/sass/app/_common/components/account-common.scss
@@ -36,6 +36,7 @@
     @include mobile-or-tablet-screen {
         padding: 1.6rem;
         height: 100%;
+        overflow-y: scroll;
 
         & .onfido-sdk-ui-PageTitle {
             &-titleWrapper {


### PR DESCRIPTION
## Changes:

Adjust the spacing between the **personal details and Onfido** sections to prevent excessive **white space** on screens with height **>1024**. 
Resolve mobile screen scroll issues 

Issues fixed:

scroll issue:

https://github.com/binary-com/deriv-app/assets/158162395/3cdef045-f8c7-44ca-8e8c-c98424155ad9

White space issue:

<img width="244" alt="Screenshot 2024-06-13 at 3 28 20 PM" src="https://github.com/fasihali-deriv/deriv-app/assets/158162395/1ab77abf-0e7e-400d-b003-e663ac2d73b8">









